### PR TITLE
Point download link to the right repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Speech library for Arduino
 
 Quick start
 -----------
-[Download the .zip file from the link at the top of the page or click here.](https://github.com/going-digital/Talkie/zipball/master) Install the "talkie" directory in your Arduino / libraries directory. Restart the Arduino software, and pick one of the examples from the Talkie section. Program it onto a 168 or 328 based Arduino (Uno, Duemilanove or Diecimila - not a Mega or Leonardo).
+[Download the .zip file from the link at the top of the page or click here.](https://github.com/PaulStoffregen/Talkie/zipball/master) Install the "talkie" directory in your Arduino / libraries directory. Restart the Arduino software, and pick one of the examples from the Talkie section. Program it onto a 168 or 328 based Arduino (Uno, Duemilanove or Diecimila - not a Mega or Leonardo).
 
 Connect headphones or an audio amplifier to digital pin 3 on Arduino, or the DAC pin on Teensy.
 


### PR DESCRIPTION
Currently the download link on the README still points to going-digital/Talkie, which is not what visitors of this page want to get.